### PR TITLE
Add custom domain: uninotes.smallapp.cc

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+uninotes.smallapp.cc


### PR DESCRIPTION
Adds a CNAME file so GitHub Pages serves this site at https://uninotes.smallapp.cc instead of the github.io URL. The old github.io URL keeps redirecting. DNS (CNAME uninotes.smallapp.cc -> deekahy.github.io) is already in place.